### PR TITLE
HDDS-11386. Multithreading bug in ContainerBalancerTask

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/AbstractFindTargetGreedy.java
@@ -32,11 +32,10 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.slf4j.Logger;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -46,7 +45,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
   private Logger logger;
   private ContainerManager containerManager;
   private PlacementPolicyValidateProxy placementPolicyValidateProxy;
-  private Map<DatanodeDetails, Long> sizeEnteringNode;
+  private ConcurrentHashMap<DatanodeDetails, Long> sizeEnteringNode;
   private NodeManager nodeManager;
   private ContainerBalancerConfiguration config;
   private Double upperLimit;
@@ -56,7 +55,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
       ContainerManager containerManager,
       PlacementPolicyValidateProxy placementPolicyValidateProxy,
       NodeManager nodeManager) {
-    sizeEnteringNode = new HashMap<>();
+    sizeEnteringNode = new ConcurrentHashMap<>();
     this.containerManager = containerManager;
     this.placementPolicyValidateProxy = placementPolicyValidateProxy;
     this.nodeManager = nodeManager;
@@ -280,7 +279,7 @@ public abstract class AbstractFindTargetGreedy implements FindTargetStrategy {
   }
 
   @Override
-  public Map<DatanodeDetails, Long> getSizeEnteringNodes() {
+  public ConcurrentHashMap<DatanodeDetails, Long> getSizeEnteringNodes() {
     return sizeEnteringNode;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -117,7 +118,7 @@ public class ContainerBalancerTask implements Runnable {
   private IterationResult iterationResult;
   private int nextIterationIndex;
   private boolean delayStart;
-  private List<ContainerBalancerTaskIterationStatusInfo> iterationsStatistic;
+  private CopyOnWriteArrayList<ContainerBalancerTaskIterationStatusInfo> iterationsStatistic;
 
   /**
    * Constructs ContainerBalancerTask with the specified arguments.
@@ -166,7 +167,7 @@ public class ContainerBalancerTask implements Runnable {
       findTargetStrategy = new FindTargetGreedyByUsageInfo(containerManager,
           placementPolicyValidateProxy, nodeManager);
     }
-    this.iterationsStatistic = new ArrayList<>();
+    this.iterationsStatistic = new CopyOnWriteArrayList<>();
   }
 
   /**
@@ -342,7 +343,7 @@ public class ContainerBalancerTask implements Runnable {
     iterationsStatistic.add(iterationStatistic);
   }
 
-  public List<ContainerBalancerTaskIterationStatusInfo> getCurrentIterationsStatistic() {
+  public CopyOnWriteArrayList<ContainerBalancerTaskIterationStatusInfo> getCurrentIterationsStatistic() {
 
     int lastIterationNumber = iterationsStatistic.stream()
         .mapToInt(ContainerBalancerTaskIterationStatusInfo::getIterationNumber)
@@ -380,7 +381,7 @@ public class ContainerBalancerTask implements Runnable {
                 )
             )
     );
-    List<ContainerBalancerTaskIterationStatusInfo> resultList = new ArrayList<>(iterationsStatistic);
+    CopyOnWriteArrayList<ContainerBalancerTaskIterationStatusInfo> resultList = new CopyOnWriteArrayList<>(iterationsStatistic);
     resultList.add(currentIterationStatistic);
     return resultList;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTask.java
@@ -381,7 +381,8 @@ public class ContainerBalancerTask implements Runnable {
                 )
             )
     );
-    CopyOnWriteArrayList<ContainerBalancerTaskIterationStatusInfo> resultList = new CopyOnWriteArrayList<>(iterationsStatistic);
+    CopyOnWriteArrayList<ContainerBalancerTaskIterationStatusInfo> resultList =
+        new CopyOnWriteArrayList<>(iterationsStatistic);
     resultList.add(currentIterationStatistic);
     return resultList;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerTaskIterationStatusInfo.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hdds.scm.container.balancer;
 
-import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Information about balancer task iteration.
@@ -33,8 +33,8 @@ public class ContainerBalancerTaskIterationStatusInfo {
   private final long containerMovesCompleted;
   private final long containerMovesFailed;
   private final long containerMovesTimeout;
-  private final Map<UUID, Long> sizeEnteringNodesGB;
-  private final Map<UUID, Long> sizeLeavingNodesGB;
+  private final ConcurrentHashMap<UUID, Long> sizeEnteringNodesGB;
+  private final ConcurrentHashMap<UUID, Long> sizeLeavingNodesGB;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public ContainerBalancerTaskIterationStatusInfo(
@@ -46,8 +46,8 @@ public class ContainerBalancerTaskIterationStatusInfo {
       long containerMovesCompleted,
       long containerMovesFailed,
       long containerMovesTimeout,
-      Map<UUID, Long> sizeEnteringNodesGB,
-      Map<UUID, Long> sizeLeavingNodesGB) {
+      ConcurrentHashMap<UUID, Long> sizeEnteringNodesGB,
+      ConcurrentHashMap<UUID, Long> sizeLeavingNodesGB) {
     this.iterationNumber = iterationNumber;
     this.iterationResult = iterationResult;
     this.sizeScheduledForMoveGB = sizeScheduledForMoveGB;
@@ -92,11 +92,11 @@ public class ContainerBalancerTaskIterationStatusInfo {
     return containerMovesTimeout;
   }
 
-  public Map<UUID, Long> getSizeEnteringNodesGB() {
+  public ConcurrentHashMap<UUID, Long> getSizeEnteringNodesGB() {
     return sizeEnteringNodesGB;
   }
 
-  public Map<UUID, Long> getSizeLeavingNodesGB() {
+  public ConcurrentHashMap<UUID, Long> getSizeLeavingNodesGB() {
     return sizeLeavingNodesGB;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceGreedy.java
@@ -26,11 +26,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The selection criteria for selecting source datanodes , the containers of
@@ -39,14 +38,14 @@ import java.util.UUID;
 public class FindSourceGreedy implements FindSourceStrategy {
   private static final Logger LOG =
       LoggerFactory.getLogger(FindSourceGreedy.class);
-  private Map<DatanodeDetails, Long> sizeLeavingNode;
+  private ConcurrentHashMap<DatanodeDetails, Long> sizeLeavingNode;
   private PriorityQueue<DatanodeUsageInfo> potentialSources;
   private NodeManager nodeManager;
   private ContainerBalancerConfiguration config;
   private Double lowerLimit;
 
   FindSourceGreedy(NodeManager nodeManager) {
-    sizeLeavingNode = new HashMap<>();
+    sizeLeavingNode = new ConcurrentHashMap<>();
     potentialSources = new PriorityQueue<>((a, b) -> {
       double currentUsageOfA = a.calculateUtilization(
           -sizeLeavingNode.get(a.getDatanodeDetails()));
@@ -203,7 +202,7 @@ public class FindSourceGreedy implements FindSourceStrategy {
   }
 
   @Override
-  public Map<DatanodeDetails, Long> getSizeLeavingNodes() {
+  public ConcurrentHashMap<DatanodeDetails, Long> getSizeLeavingNodes() {
     return sizeLeavingNode;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceStrategy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindSourceStrategy.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import jakarta.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This interface can be used to implement strategies to get a
@@ -87,5 +87,5 @@ public interface FindSourceStrategy {
    */
   void resetPotentialSources(@Nonnull Collection<DatanodeDetails> sources);
 
-  Map<DatanodeDetails, Long> getSizeLeavingNodes();
+  ConcurrentHashMap<DatanodeDetails, Long> getSizeLeavingNodes();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetStrategy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/FindTargetStrategy.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import jakarta.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This interface can be used to implement strategies to find a target for a
@@ -70,5 +70,5 @@ public interface FindTargetStrategy {
    */
   void resetPotentialTargets(@Nonnull Collection<DatanodeDetails> targets);
 
-  Map<DatanodeDetails, Long> getSizeEnteringNodes();
+  ConcurrentHashMap<DatanodeDetails, Long> getSizeEnteringNodes();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The method `getCurrentIterationsStatistic` accesses various data structures and objects. A reading thread that's executing this method could be reading while the balancing thread is writing to these data structures and objects. This is code is not thread safe and can cause unpredictable errors. 

Replaced `List` with `CopyOnWriteArrayList`.

## What is the link to the Apache JIRA
[HDDS-11386](https://issues.apache.org/jira/browse/HDDS-11386)

## How was this patch tested?
Test
