### PR TITLE
# This is a combination of 8 commits.

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestReservedVolumeSpace.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.container.common.volume;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED_PERCENT_DEFAULT;
-import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -202,12 +201,12 @@ public class TestReservedVolumeSpace {
     assertEquals(minSpace, conf.getObject(DatanodeConfiguration.class).getMinFreeSpace(capacity));
 
     conf.setFloat(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT, 0.01f);
-    // When both are set, minSpace will be used
+    // When both are set, max(minSpace, %cent), minSpace will be used
     assertEquals(minSpace, conf.getObject(DatanodeConfiguration.class).getMinFreeSpace(capacity));
 
-    // capacity * 1% = 10
-    conf.unset(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE);
-    assertEquals(10, conf.getObject(DatanodeConfiguration.class).getMinFreeSpace(capacity));
+    conf.setFloat(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE_PERCENT, 1f);
+    // When both are set, max(minSpace, %cent), hence %cent will be used
+    assertEquals(1000, conf.getObject(DatanodeConfiguration.class).getMinFreeSpace(capacity));
   }
 
   private long getExpectedDefaultReserved(HddsVolume volume) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -407,7 +407,9 @@ public class TestReplicationSupervisor {
     // Initially volume has 0 used space
     assertEquals(0, usedSpace);
     // Increase committed bytes so that volume has only remaining 3 times container size space
-    long initialCommittedBytes = vol1.getCurrentUsage().getCapacity() - containerMaxSize * 3;
+    long minFreeSpace =
+        conf.getObject(DatanodeConfiguration.class).getMinFreeSpace(vol1.getCurrentUsage().getCapacity());
+    long initialCommittedBytes = vol1.getCurrentUsage().getCapacity() - containerMaxSize * 3 - minFreeSpace;
     vol1.incCommittedBytes(initialCommittedBytes);
     ContainerReplicator replicator =
         new DownloadAndImportReplicator(conf, set, importer, moc);

--- a/hadoop-hdds/docs/content/design/dn-min-space-configuration.md
+++ b/hadoop-hdds/docs/content/design/dn-min-space-configuration.md
@@ -1,0 +1,108 @@
+---
+title: Minimum free space configuration for datanode volumes
+summary: Describe proposal for minimum free space configuration which volume must have to function correctly.
+date: 2025-05-05
+jira: HDDS-12928
+status: implemented
+author: Sumit Agrawal
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+Volume in the datanode stores the container data and metadata (rocks db co-located on the volume).
+There are various parallel operation going on such as import container, export container, write and delete data blocks,
+container repairs, create and delete containers. The space is also required for volume db to perform compaction at regular interval.
+This is hard to capture exact usages and free available space. So, this is required to configure minimum free space
+so that datanode operation can perform without any corruption and environment being stuck and support read of data.
+
+This free space is used to ensure volume allocation if `required space < (volume available space - free space - reserved space - committed space)`.
+Any container creation and import container need to ensure that this constraint is met. And block byte writes need ensure that `free space` space is available.
+Note: Any issue related to ensuring free space is tracked with separate JIRA.
+
+# Existing configuration (before HDDS-12928)
+Two configurations are provided,
+- hdds.datanode.volume.min.free.space  (default: 5GB)
+- hdds.datanode.volume.min.free.space.percent
+
+1. If nothing is configured, takes default value as 5GB
+2. if both are configured, priority to hdds.datanode.volume.min.free.space
+3. else respective configuration is used.
+
+# Problem Statement
+
+- With 5GB default configuration, its not avoiding full disk scenario due to error in ensuring free space availability.
+This is due to container size being imported is 5GB which is near boundary, and other parallel operation.
+- Volume DB size can increase with increase in disk space as container and blocks it can hold can more and hence metadata.
+- Volume DB size can also vary due to small files and big files combination, as more small files can lead to more metadata.
+
+Solution involves
+- appropriate default min free space
+- depends on disk size variation
+
+# Approach 1 Combination of minimum free space and percent increase on disk size
+
+Configuration:
+1. Minimum free space: hdds.datanode.volume.min.free.space: default value `20GB`
+2. disk size variation: hdds.datanode.volume.min.free.space.percent: default 0.1% or 0.001 ratio
+
+Minimum free space = Max (`<Min free space>`, `<percent disk space>`)
+
+| Disk space | Min Free Space (percent: 1%) | Min Free Space ( percent: 0.1%) |
+| -- |------------------------------|---------------------------------|
+| 100 GB | 20 GB                        | 20 GB (min space default)       |
+| 1 TB | 20 GB                        | 20 GB (min space default)       |
+| 10 TB | 100 GB                       | 20 GB  (min space default) |
+| 100 TB | 1 TB                         | 100 GB                          |
+
+considering above table with this solution,
+- 0.1 % to be sufficient to hold almost all cases, as not observed any dn volume db to be more that 1-2 GB
+
+# Approach 2 Only minimum free space configuration
+
+Considering above approach, 20 GB as default should be sufficient for most of the disk, as usually disk size is 10-15TB as seen.
+Higher disk is rarely used, and instead multiple volumes are attached to same DN with multiple disk.
+
+Considering this scenario, Minimum free space: `hdds.datanode.volume.min.free.space` itself is enough and
+percent based configuration can be removed.
+
+### Compatibility
+If `hdds.datanode.volume.min.free.space.percent` is configured, this should not have any impact
+as default value is increased to 20GB which will consider most of the use case.
+
+# Approach 3 Combination of maximum free space and percent configuration on disk size
+
+Configuration:
+1. Maximum free space: hdds.datanode.volume.min.free.space: default value `20GB`
+2. disk size variation: hdds.datanode.volume.min.free.space.percent: default 10% or 0.1 ratio
+
+Minimum free space = **Min** (`<Max free space>`, `<percent disk space>`)
+> Difference with approach `one` is, Min function over the 2 above configuration
+
+| Disk space | Min Free Space (20GB, 10% of disk) |
+| -- |------------------------------------|
+| 10 GB | 1 GB (=Min(20GB, 1GB)              |
+| 100 GB | 10 GB (=Min(20GB, 10GB)            |
+| 1 TB | 20 GB   (=Min(20GB, 100GB)         |
+| 10 TB | 20 GB (=Min(20GB, 1TB)             |
+| 100 TB | 20GB  (=Min(20GB, 10TB)            |
+
+This case is more useful for test environment where disk space is less and no need any additional configuration.
+
+# Conclusion
+1. Going with Approach 1
+- Approach 2 is simple setting only min-free-space, but it does not expand with higher disk size.
+- Approach 3 is more applicable for test environment where disk space is less, else same as Approach 2.
+- So Approach 1 is selected considering advantage where higher free space can be configured by default.
+2. Min Space will be 20GB as default
+
+

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/.env
@@ -20,4 +20,5 @@ HADOOP_VERSION=${hadoop.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_TESTKRB5_IMAGE=${docker.ozone-testkr5b.image}
+OZONE_VOLUME=./data
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/debug-tools.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/debug-tools.yaml
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+x-debug-tools-config:
+  &common-env-file
+  dns_search: .
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
+  env_file:
+    - ./docker-config
+
+x-volumes:
+  - &keytabs ../_keytabs:/etc/security/keytabs
+  - &krb5conf ./krb5.conf:/etc/krb5.conf
+  - &ozone-dir ../..:/opt/hadoop
+  - &transformation ../../libexec/transformation.py:/opt/hadoop/libexec/transformation.py
+
+services:
+  kdc:
+    volumes:
+      - *keytabs
+      - *ozone-dir
+  kms:
+    volumes:
+      - ${OZONE_VOLUME}/kms:/data
+      - *keytabs
+      - *krb5conf
+      - *transformation
+  datanode1:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/dn1:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  datanode2:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/dn2:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  datanode3:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/dn3:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  datanode4:
+    <<: *common-env-file
+    ports:
+      - 9870:9999
+    command: ["/opt/hadoop/bin/ozone","datanode"]
+    extra_hosts:
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
+      - "recon=172.25.0.115"
+    environment:
+      WAITFOR: scm3.org:9894
+      OZONE_OPTS:
+    networks:
+      ozone_net:
+        ipv4_address: 172.25.0.105
+    volumes:
+      - ${OZONE_VOLUME}/dn4:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  datanode5:
+    <<: *common-env-file
+    ports:
+      - 9872:9999
+    command: [ "/opt/hadoop/bin/ozone","datanode" ]
+    extra_hosts:
+      - "scm1.org=172.25.0.116"
+      - "scm2.org=172.25.0.117"
+      - "scm3.org=172.25.0.118"
+      - "recon=172.25.0.115"
+    environment:
+      WAITFOR: scm3.org:9894
+      OZONE_OPTS:
+    networks:
+      ozone_net:
+        ipv4_address: 172.25.0.106
+    volumes:
+      - ${OZONE_VOLUME}/dn5:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  om1:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/om1:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  om2:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/om2:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  om3:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/om3:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  s3g:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/s3g:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  scm1.org:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/scm1:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  scm2.org:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/scm2:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  scm3.org:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/scm3:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+  recon:
+    <<: *common-env-file
+    volumes:
+      - ${OZONE_VOLUME}/recon:/data
+      - *keytabs
+      - *krb5conf
+      - *ozone-dir
+
+

--- a/hadoop-ozone/dist/src/main/k8s/definitions/ozone/config.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/ozone/config.yaml
@@ -28,6 +28,7 @@ data:
   OZONE-SITE.XML_hdds.datanode.dir: "/data/storage"
   OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "3"
   OZONE-SITE.XML_ozone.datanode.pipeline.limit: "1"
+  OZONE-SITE.XML_hdds.datanode.volume.min.free.space: "1GB"
   OZONE-SITE.XML_ozone.metadata.dirs: "/data/metadata"
   OZONE-SITE.XML_ozone.om.address: "om-0.om"
   OZONE-SITE.XML_ozone.recon.address: "recon-0.recon"

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/config-configmap.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/config-configmap.yaml
@@ -28,6 +28,7 @@ data:
   OZONE-SITE.XML_hdds.datanode.dir: /data/storage
   OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "3"
   OZONE-SITE.XML_ozone.datanode.pipeline.limit: "1"
+  OZONE-SITE.XML_hdds.datanode.volume.min.free.space: "1GB"
   OZONE-SITE.XML_ozone.metadata.dirs: /data/metadata
   OZONE-SITE.XML_ozone.om.address: om-0.om
   OZONE-SITE.XML_ozone.recon.address: recon-0.recon

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/config-configmap.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/config-configmap.yaml
@@ -28,6 +28,7 @@ data:
   OZONE-SITE.XML_hdds.datanode.dir: /data/storage
   OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "3"
   OZONE-SITE.XML_ozone.datanode.pipeline.limit: "1"
+  OZONE-SITE.XML_hdds.datanode.volume.min.free.space: "1GB"
   OZONE-SITE.XML_ozone.metadata.dirs: /data/metadata
   OZONE-SITE.XML_ozone.om.address: om-0.om
   OZONE-SITE.XML_ozone.recon.address: recon-0.recon

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/config-configmap.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/config-configmap.yaml
@@ -28,6 +28,7 @@ data:
   OZONE-SITE.XML_hdds.datanode.dir: /data/storage
   OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "3"
   OZONE-SITE.XML_ozone.datanode.pipeline.limit: "1"
+  OZONE-SITE.XML_hdds.datanode.volume.min.free.space: "1GB"
   OZONE-SITE.XML_ozone.metadata.dirs: /data/metadata
   OZONE-SITE.XML_ozone.om.address: om-0.om
   OZONE-SITE.XML_ozone.recon.address: recon-0.recon

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/config-configmap.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-ha/config-configmap.yaml
@@ -28,6 +28,7 @@ data:
   OZONE-SITE.XML_hdds.datanode.dir: /data/storage
   OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "3"
   OZONE-SITE.XML_ozone.datanode.pipeline.limit: "1"
+  OZONE-SITE.XML_hdds.datanode.volume.min.free.space: "1GB"
   OZONE-SITE.XML_ozone.metadata.dirs: /data/metadata
   OZONE-SITE.XML_ozone.om.address: om-0.om
   OZONE-SITE.XML_ozone.recon.address: recon-0.recon

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/config-configmap.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/config-configmap.yaml
@@ -28,6 +28,7 @@ data:
   OZONE-SITE.XML_hdds.datanode.dir: /data/storage
   OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "3"
   OZONE-SITE.XML_ozone.datanode.pipeline.limit: "1"
+  OZONE-SITE.XML_hdds.datanode.volume.min.free.space: "1GB"
   OZONE-SITE.XML_ozone.metadata.dirs: /data/metadata
   OZONE-SITE.XML_ozone.om.address: om-0.om
   OZONE-SITE.XML_ozone.recon.address: recon-0.recon

--- a/hadoop-ozone/dist/src/main/smoketest/debug/auditparser.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/auditparser.robot
@@ -25,11 +25,11 @@ Test Timeout        5 minutes
 ${user}              hadoop
 ${buckets}           5
 ${auditworkdir}      /tmp
+${OM}                om1
 
 *** Keywords ***
 Set username
-    ${hostname} =          Execute         hostname
-    Set Suite Variable     ${user}         testuser/${hostname}@EXAMPLE.COM
+    Set Suite Variable     ${user}         testuser/${OM}@EXAMPLE.COM
     [return]               ${user}
 
 Create data

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests-ec3-2.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests-ec3-2.robot
@@ -29,17 +29,18 @@ ${BUCKET}           cli-debug-bucket
 ${TESTFILE}         testfile
 ${EC_DATA}          3
 ${EC_PARITY}        2
+${OM_SERVICE_ID}    %{OM_SERVICE_ID}
 
 *** Keywords ***
 Create Volume Bucket
-    Execute             ozone sh volume create o3://om/${VOLUME}
-    Execute             ozone sh bucket create o3://om/${VOLUME}/${BUCKET}
+    Execute             ozone sh volume create o3://${OM_SERVICE_ID}/${VOLUME}
+    Execute             ozone sh bucket create o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}
 
 Create EC key
     [arguments]       ${bs}    ${count}    
 
     Execute           dd if=/dev/urandom of=${TEMP_DIR}/testfile bs=${bs} count=${count}
-    Execute           ozone sh key put o3://om/${VOLUME}/${BUCKET}/testfile ${TEMP_DIR}/testfile -r rs-${EC_DATA}-${EC_PARITY}-1024k -t EC
+    Execute           ozone sh key put o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/testfile ${TEMP_DIR}/testfile -r rs-${EC_DATA}-${EC_PARITY}-1024k -t EC
 
 *** Test Cases ***
 0 data block
@@ -87,5 +88,5 @@ Create EC key
 
 Test ozone debug replicas chunk-info
     Create EC key     1048576    3
-    ${count} =        Execute           ozone debug replicas chunk-info o3://om/${VOLUME}/${BUCKET}/testfile | jq '[.keyLocations[0][] | select(.file | test("\\\\.block$")) | .file] | length'
+    ${count} =        Execute           ozone debug replicas chunk-info o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/testfile | jq '[.keyLocations[0][] | select(.file | test("\\\\.block$")) | .file] | length'
     Should Be Equal As Integers         ${count}          5

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests-ec6-3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests-ec6-3.robot
@@ -28,13 +28,14 @@ ${BUCKET}           cli-debug-bucket
 ${TESTFILE}         testfile
 ${EC_DATA}          6
 ${EC_PARITY}        3
+${OM_SERVICE_ID}    %{OM_SERVICE_ID}
 
 *** Keywords ***
 Create EC key
     [arguments]       ${bs}    ${count}
 
     Execute           dd if=/dev/urandom of=${TEMP_DIR}/testfile bs=${bs} count=${count}
-    Execute           ozone sh key put o3://om/${VOLUME}/${BUCKET}/testfile ${TEMP_DIR}/testfile -r rs-${EC_DATA}-${EC_PARITY}-1024k -t EC
+    Execute           ozone sh key put o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/testfile ${TEMP_DIR}/testfile -r rs-${EC_DATA}-${EC_PARITY}-1024k -t EC
 
 *** Test Cases ***
 0 data block
@@ -95,5 +96,5 @@ Create EC key
 
 Test ozone debug replicas chunk-info
     Create EC key     1048576    6
-    ${count} =        Execute           ozone debug replicas chunk-info o3://om/${VOLUME}/${BUCKET}/testfile | jq '[.keyLocations[0][] | select(.file | test("\\\\.block$")) | .file] | length'
+    ${count} =        Execute           ozone debug replicas chunk-info o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/testfile | jq '[.keyLocations[0][] | select(.file | test("\\\\.block$")) | .file] | length'
     Should Be Equal As Integers         ${count}           9

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -27,17 +27,18 @@ ${VOLUME}           cli-debug-volume${PREFIX}
 ${BUCKET}           cli-debug-bucket
 ${DEBUGKEY}         debugKey
 ${TESTFILE}         testfile
+${OM_SERVICE_ID}    %{OM_SERVICE_ID}
 
 *** Keywords ***
 Write keys
-    Execute             ozone sh volume create o3://om/${VOLUME} --space-quota 100TB --namespace-quota 100
-    Execute             ozone sh bucket create o3://om/${VOLUME}/${BUCKET} --space-quota 1TB
+    Execute             ozone sh volume create o3://${OM_SERVICE_ID}/${VOLUME} --space-quota 100TB --namespace-quota 100
+    Execute             ozone sh bucket create o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET} --space-quota 1TB
     Execute             dd if=/dev/urandom of=${TEMP_DIR}/${TESTFILE} bs=100000 count=15
-    Execute             ozone sh key put o3://om/${VOLUME}/${BUCKET}/${TESTFILE} ${TEMP_DIR}/${TESTFILE}
+    Execute             ozone sh key put o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE} ${TEMP_DIR}/${TESTFILE}
 
 *** Test Cases ***
 Test ozone debug replicas verify checksums
-    ${output} =    Execute   ozone debug replicas verify --checksums o3://om/${VOLUME}/${BUCKET}/${TESTFILE} --output-dir ${TEMP_DIR}
+    ${output} =    Execute   ozone debug replicas verify --checksums o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE} --output-dir ${TEMP_DIR}
     ${json} =      Evaluate  json.loads('''${output}''')      json
 
     # 'keys' array should be empty if all keys and their replicas passed checksum verification

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
@@ -18,9 +18,12 @@ Documentation       Keyword definitions for Ozone Debug CLI tests
 Library             Collections
 Resource            ../lib/os.robot
 
+*** Variables ***
+${OM_SERVICE_ID}                    %{OM_SERVICE_ID}
+
 *** Keywords ***
 Execute replicas verify checksums CLI tool
-    Execute                         ozone debug -Dozone.network.topology.aware.read=true replicas verify --checksums --output-dir ${TEMP_DIR} o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
+    Execute                         ozone debug -Dozone.network.topology.aware.read=true replicas verify --checksums --output-dir ${TEMP_DIR} o3://${OM_SERVICE_ID}/${VOLUME}/${BUCKET}/${TESTFILE}
     ${directory} =                  Execute     ls -d ${TEMP_DIR}/${VOLUME}_${BUCKET}_${TESTFILE}_*/ | tail -n 1
     Directory Should Exist          ${directory}
     File Should Exist               ${directory}/${TESTFILE}_manifest

--- a/hadoop-ozone/integration-test-recon/src/test/resources/ozone-site.xml
+++ b/hadoop-ozone/integration-test-recon/src/test/resources/ozone-site.xml
@@ -110,4 +110,8 @@
     <name>ozone.client.datastream.window.size</name>
     <value>8MB</value>
   </property>
+  <property>
+    <name>hdds.datanode.volume.min.free.space</name>
+    <value>5GB</value>
+  </property>
 </configuration>

--- a/hadoop-ozone/integration-test-s3/src/test/resources/ozone-site.xml
+++ b/hadoop-ozone/integration-test-s3/src/test/resources/ozone-site.xml
@@ -125,5 +125,8 @@
     <name>ozone.client.datastream.window.size</name>
     <value>8MB</value>
   </property>
-
+  <property>
+    <name>hdds.datanode.volume.min.free.space</name>
+    <value>5GB</value>
+  </property>
 </configuration>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestRefreshVolumeUsageHandler.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_NODE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.HDDS_DATANODE_VOLUME_MIN_FREE_SPACE;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -56,6 +57,7 @@ public class TestRefreshVolumeUsageHandler {
     //setup a cluster (1G free space is enough for a unit test)
     conf = new OzoneConfiguration();
     conf.set(OZONE_SCM_CONTAINER_SIZE, "1GB");
+    conf.set(HDDS_DATANODE_VOLUME_MIN_FREE_SPACE, "5GB");
     conf.set(HDDS_NODE_REPORT_INTERVAL, "1s");
     conf.set("hdds.datanode.du.factory.classname",
         "org.apache.hadoop.ozone.container.common.volume.HddsVolumeFactory");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingServiceIntegrationTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestSnapshotDeletingServiceIntegrationTest.java
@@ -620,9 +620,9 @@ public class TestSnapshotDeletingServiceIntegrationTest {
              om.getOmSnapshotManager().getSnapshot(testBucket.getVolumeName(), testBucket.getName(),
                  testBucket.getName() + "snap2")) {
       renamesKeyEntries = snapshot.get().getKeyManager().getRenamesKeyEntries(testBucket.getVolumeName(),
-          testBucket.getName(), "", 1000);
+          testBucket.getName(), "", (kv) -> true, 1000);
       deletedKeyEntries = snapshot.get().getKeyManager().getDeletedKeyEntries(testBucket.getVolumeName(),
-          testBucket.getName(), "", 1000);
+          testBucket.getName(), "", (kv) -> true, 1000);
       deletedDirEntries = snapshot.get().getKeyManager().getDeletedDirEntries(testBucket.getVolumeName(),
           testBucket.getName(), 1000);
     }
@@ -658,20 +658,20 @@ public class TestSnapshotDeletingServiceIntegrationTest {
                  testBucket.getName() + "snap2")) {
       Assertions.assertEquals(Collections.emptyList(),
           snapshot.get().getKeyManager().getRenamesKeyEntries(testBucket.getVolumeName(),
-          testBucket.getName(), "", 1000));
+          testBucket.getName(), "", (kv) -> true, 1000));
       Assertions.assertEquals(Collections.emptyList(),
           snapshot.get().getKeyManager().getDeletedKeyEntries(testBucket.getVolumeName(),
-          testBucket.getName(), "", 1000));
+          testBucket.getName(), "", (kv) -> true, 1000));
       Assertions.assertEquals(Collections.emptyList(),
           snapshot.get().getKeyManager().getDeletedDirEntries(testBucket.getVolumeName(),
           testBucket.getName(), 1000));
     }
     List<Table.KeyValue<String, String>> aosRenamesKeyEntries =
         om.getKeyManager().getRenamesKeyEntries(testBucket.getVolumeName(),
-            testBucket.getName(), "", 1000);
+            testBucket.getName(), "", (kv) -> true, 1000);
     List<Table.KeyValue<String, List<OmKeyInfo>>> aosDeletedKeyEntries =
         om.getKeyManager().getDeletedKeyEntries(testBucket.getVolumeName(),
-            testBucket.getName(), "", 1000);
+            testBucket.getName(), "", (kv) -> true, 1000);
     List<Table.KeyValue<String, OmKeyInfo>> aosDeletedDirEntries =
         om.getKeyManager().getDeletedDirEntries(testBucket.getVolumeName(),
             testBucket.getName(), 1000);

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1392,6 +1392,7 @@ message PurgeKeysRequest {
     repeated SnapshotMoveKeyInfos keysToUpdate = 3;
     // previous snapshotID can also be null & this field would be absent in older requests.
     optional NullableUUID expectedPreviousSnapshotID = 4;
+    repeated string renamedKeys = 5;
 }
 
 message PurgeKeysResponse {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeletingServiceMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeletingServiceMetrics.java
@@ -65,6 +65,8 @@ public final class DeletingServiceMetrics {
    */
   @Metric("Total no. of keys purged")
   private MutableGaugeLong numKeysPurged;
+  @Metric("Total no. of rename entries purged")
+  private MutableGaugeLong numRenameEntriesPurged;
 
   private DeletingServiceMetrics() {
     this.registry = new MetricsRegistry(METRICS_SOURCE_NAME);
@@ -152,6 +154,10 @@ public final class DeletingServiceMetrics {
 
   public void incrNumKeysPurged(long keysPurged) {
     this.numKeysPurged.incr(keysPurged);
+  }
+
+  public void incrNumRenameEntriesPurged(long renameEntriesPurged) {
+    this.numRenameEntriesPurged.incr(renameEntriesPurged);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.service.CompactionService;
 import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
 import org.apache.hadoop.ozone.om.service.KeyDeletingService;
@@ -148,13 +149,16 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
   /**
    * Returns a list rename entries from the snapshotRenamedTable.
    *
-   * @param size max number of keys to return.
+   * @param count max number of keys to return.
+   * @param filter filter to apply on the entries.
    * @return a Pair of list of {@link org.apache.hadoop.hdds.utils.db.Table.KeyValue} representing the keys in the
    * underlying metadataManager.
    * @throws IOException
    */
   List<Table.KeyValue<String, String>> getRenamesKeyEntries(
-      String volume, String bucket, String startKey, int size) throws IOException;
+      String volume, String bucket, String startKey,
+      CheckedFunction<Table.KeyValue<String, String>, Boolean, IOException> filter, int count)
+      throws IOException;
 
 
   /**
@@ -178,13 +182,16 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
   /**
    * Returns a list deleted entries from the deletedTable.
    *
-   * @param size max number of keys to return.
+   * @param count max number of keys to return.
+   * @param filter filter to apply on the entries.
    * @return a Pair of list of {@link org.apache.hadoop.hdds.utils.db.Table.KeyValue} representing the keys in the
    * underlying metadataManager.
    * @throws IOException
    */
   List<Table.KeyValue<String, List<OmKeyInfo>>> getDeletedKeyEntries(
-      String volume, String bucket, String startKey, int size) throws IOException;
+      String volume, String bucket, String startKey,
+      CheckedFunction<Table.KeyValue<String, RepeatedOmKeyInfo>, Boolean, IOException> filter,
+      int count) throws IOException;
 
   /**
    * Returns the names of up to {@code count} open keys whose age is

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -797,7 +797,9 @@ public class KeyManagerImpl implements KeyManager {
 
   private <V, R> List<Table.KeyValue<String, R>> getTableEntries(String startKey,
           TableIterator<String, ? extends Table.KeyValue<String, V>> tableIterator,
-          Function<V, R> valueFunction, int size) throws IOException {
+          Function<V, R> valueFunction,
+          CheckedFunction<Table.KeyValue<String, V>, Boolean, IOException> filter,
+          int size) throws IOException {
     List<Table.KeyValue<String, R>> entries = new ArrayList<>();
     /* Seek to the start key if it's not null. The next key in queue is ensured to start with the bucket
          prefix, {@link org.apache.hadoop.hdds.utils.db.Table#iterator(bucketPrefix)} would ensure this.
@@ -810,7 +812,7 @@ public class KeyManagerImpl implements KeyManager {
     int currentCount = 0;
     while (tableIterator.hasNext() && currentCount < size) {
       Table.KeyValue<String, V> kv = tableIterator.next();
-      if (kv != null) {
+      if (kv != null && filter.apply(kv)) {
         entries.add(Table.newKeyValue(kv.getKey(), valueFunction.apply(kv.getValue())));
         currentCount++;
       }
@@ -832,11 +834,12 @@ public class KeyManagerImpl implements KeyManager {
 
   @Override
   public List<Table.KeyValue<String, String>> getRenamesKeyEntries(
-      String volume, String bucket, String startKey, int size) throws IOException {
+      String volume, String bucket, String startKey,
+      CheckedFunction<Table.KeyValue<String, String>, Boolean, IOException> filter, int size) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
     try (TableIterator<String, ? extends Table.KeyValue<String, String>>
              renamedKeyIter = metadataManager.getSnapshotRenamedTable().iterator(bucketPrefix.orElse(""))) {
-      return getTableEntries(startKey, renamedKeyIter, Function.identity(), size);
+      return getTableEntries(startKey, renamedKeyIter, Function.identity(), filter, size);
     }
   }
 
@@ -880,11 +883,13 @@ public class KeyManagerImpl implements KeyManager {
 
   @Override
   public List<Table.KeyValue<String, List<OmKeyInfo>>> getDeletedKeyEntries(
-      String volume, String bucket, String startKey, int size) throws IOException {
+      String volume, String bucket, String startKey,
+      CheckedFunction<Table.KeyValue<String, RepeatedOmKeyInfo>, Boolean, IOException> filter,
+      int size) throws IOException {
     Optional<String> bucketPrefix = getBucketPrefix(volume, bucket, false);
     try (TableIterator<String, ? extends Table.KeyValue<String, RepeatedOmKeyInfo>>
              delKeyIter = metadataManager.getDeletedTable().iterator(bucketPrefix.orElse(""))) {
-      return getTableEntries(startKey, delKeyIter, RepeatedOmKeyInfo::cloneOmKeyInfoList, size);
+      return getTableEntries(startKey, delKeyIter, RepeatedOmKeyInfo::cloneOmKeyInfoList, filter, size);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
@@ -91,6 +91,7 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
     List<String> keysToBePurgedList = new ArrayList<>();
 
     int numKeysDeleted = 0;
+    List<String> renamedKeysToBePurged = new ArrayList<>(purgeKeysRequest.getRenamedKeysList());
     for (DeletedKeys bucketWithDeleteKeys : bucketDeletedKeysList) {
       List<String> keysList = bucketWithDeleteKeys.getKeysList();
       keysToBePurgedList.addAll(keysList);
@@ -98,8 +99,9 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
     }
     DeletingServiceMetrics deletingServiceMetrics = ozoneManager.getDeletionMetrics();
     deletingServiceMetrics.incrNumKeysPurged(numKeysDeleted);
+    deletingServiceMetrics.incrNumRenameEntriesPurged(renamedKeysToBePurged.size());
 
-    if (keysToBePurgedList.isEmpty()) {
+    if (keysToBePurgedList.isEmpty() && renamedKeysToBePurged.isEmpty()) {
       return new OMKeyPurgeResponse(createErrorOMResponse(omResponse,
           new OMException("None of the keys can be purged be purged since a new snapshot was created for all the " +
               "buckets, making this request invalid", OMException.ResultCodes.KEY_DELETION_ERROR)));
@@ -118,7 +120,7 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
     }
 
     return new OMKeyPurgeResponse(omResponse.build(),
-        keysToBePurgedList, fromSnapshotInfo, keysToUpdateList);
+        keysToBePurgedList, renamedKeysToBePurged, fromSnapshotInfo, keysToUpdateList);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/SnapshotDeletingService.java
@@ -193,7 +193,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
             // Get all entries from deletedKeyTable.
             List<Table.KeyValue<String, List<OmKeyInfo>>> deletedKeyEntries =
                 snapshotKeyManager.getDeletedKeyEntries(snapInfo.getVolumeName(), snapInfo.getBucketName(),
-                    null, remaining);
+                    null, (kv) -> true, remaining);
             moveCount += deletedKeyEntries.size();
             // Get all entries from deletedDirTable.
             List<Table.KeyValue<String, OmKeyInfo>> deletedDirEntries = snapshotKeyManager.getDeletedDirEntries(
@@ -201,7 +201,7 @@ public class SnapshotDeletingService extends AbstractKeyDeletingService {
             moveCount += deletedDirEntries.size();
             // Get all entries from snapshotRenamedTable.
             List<Table.KeyValue<String, String>> renameEntries = snapshotKeyManager.getRenamesKeyEntries(
-                snapInfo.getVolumeName(), snapInfo.getBucketName(), null, remaining - moveCount);
+                snapInfo.getVolumeName(), snapInfo.getBucketName(), null, (kv) -> true, remaining - moveCount);
             moveCount += renameEntries.size();
             if (moveCount > 0) {
               List<SnapshotMoveKeyInfos> deletedKeys = new ArrayList<>(deletedKeyEntries.size());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.utils.MapBackedTableIterator;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.ratis.util.function.CheckedFunction;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -74,7 +75,8 @@ public class TestKeyManagerImpl {
       Class<V> valueClass, Table<String, V> table, int numberOfVolumes, int numberOfBucketsPerVolume,
       int numberOfKeysPerBucket, String volumeNamePrefix, String bucketNamePrefix, String keyPrefix,
       Integer volumeNumberFilter, Integer bucketNumberFilter, Integer startVolumeNumber, Integer startBucketNumber,
-      Integer startKeyNumber, int numberOfEntries) throws IOException {
+      Integer startKeyNumber, CheckedFunction<Table.KeyValue<String, V>, Boolean, IOException> filter,
+      int numberOfEntries) throws IOException {
     TreeMap<String, V> values = new TreeMap<>();
     List<Table.KeyValue<String, V>> keyValues = new ArrayList<>();
     String startKey = startVolumeNumber == null || startBucketNumber == null || startKeyNumber == null ? null
@@ -98,7 +100,13 @@ public class TestKeyManagerImpl {
     }
 
     when(table.iterator(anyString())).thenAnswer(i -> new MapBackedTableIterator<>(values, i.getArgument(0)));
-    return keyValues.subList(0, Math.min(numberOfEntries, keyValues.size()));
+    return keyValues.stream().filter(kv -> {
+      try {
+        return filter.apply(kv);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }).limit(numberOfEntries).collect(Collectors.toList());
   }
 
   @ParameterizedTest
@@ -119,10 +127,12 @@ public class TestKeyManagerImpl {
     KeyManagerImpl km = new KeyManagerImpl(null, null, metadataManager, configuration, null, null, null);
     Table<String, RepeatedOmKeyInfo> mockedDeletedTable = Mockito.mock(Table.class);
     when(metadataManager.getDeletedTable()).thenReturn(mockedDeletedTable);
+    CheckedFunction<Table.KeyValue<String, RepeatedOmKeyInfo>, Boolean, IOException> filter =
+        (kv) -> Long.parseLong(kv.getKey().split(keyPrefix)[1]) % 2 == 0;
     List<Table.KeyValue<String, List<OmKeyInfo>>> expectedEntries = mockTableIterator(
         RepeatedOmKeyInfo.class, mockedDeletedTable, numberOfVolumes, numberOfBucketsPerVolume, numberOfKeysPerBucket,
         volumeNamePrefix, bucketNamePrefix, keyPrefix, volumeNumber, bucketNumber, startVolumeNumber, startBucketNumber,
-        startKeyNumber, numberOfEntries).stream()
+        startKeyNumber, filter, numberOfEntries).stream()
         .map(kv -> {
           try {
             String key = kv.getKey();
@@ -140,9 +150,10 @@ public class TestKeyManagerImpl {
         : (String.format("/%s%010d/%s%010d/%s%010d", volumeNamePrefix, startVolumeNumber, bucketNamePrefix,
         startBucketNumber, keyPrefix, startKeyNumber));
     if (expectedException != null) {
-      assertThrows(expectedException, () -> km.getDeletedKeyEntries(volumeName, bucketName, startKey, numberOfEntries));
+      assertThrows(expectedException, () -> km.getDeletedKeyEntries(volumeName, bucketName, startKey, filter,
+          numberOfEntries));
     } else {
-      assertEquals(expectedEntries, km.getDeletedKeyEntries(volumeName, bucketName, startKey, numberOfEntries));
+      assertEquals(expectedEntries, km.getDeletedKeyEntries(volumeName, bucketName, startKey, filter, numberOfEntries));
     }
   }
 
@@ -164,19 +175,22 @@ public class TestKeyManagerImpl {
     KeyManagerImpl km = new KeyManagerImpl(null, null, metadataManager, configuration, null, null, null);
     Table<String, String> mockedRenameTable = Mockito.mock(Table.class);
     when(metadataManager.getSnapshotRenamedTable()).thenReturn(mockedRenameTable);
+    CheckedFunction<Table.KeyValue<String, String>, Boolean, IOException> filter =
+        (kv) -> Long.parseLong(kv.getKey().split("/")[3]) % 2 == 0;
     List<Table.KeyValue<String, String>> expectedEntries = mockTableIterator(
         String.class, mockedRenameTable, numberOfVolumes, numberOfBucketsPerVolume, numberOfKeysPerBucket,
         volumeNamePrefix, bucketNamePrefix, keyPrefix, volumeNumber, bucketNumber, startVolumeNumber, startBucketNumber,
-        startKeyNumber, numberOfEntries);
+        startKeyNumber, filter, numberOfEntries);
     String volumeName = volumeNumber == null ? null : (String.format("%s%010d", volumeNamePrefix, volumeNumber));
     String bucketName = bucketNumber == null ? null : (String.format("%s%010d", bucketNamePrefix, bucketNumber));
     String startKey = startVolumeNumber == null || startBucketNumber == null || startKeyNumber == null ? null
         : (String.format("/%s%010d/%s%010d/%s%010d", volumeNamePrefix, startVolumeNumber, bucketNamePrefix,
         startBucketNumber, keyPrefix, startKeyNumber));
     if (expectedException != null) {
-      assertThrows(expectedException, () -> km.getRenamesKeyEntries(volumeName, bucketName, startKey, numberOfEntries));
+      assertThrows(expectedException, () -> km.getRenamesKeyEntries(volumeName, bucketName, startKey,
+          filter, numberOfEntries));
     } else {
-      assertEquals(expectedEntries, km.getRenamesKeyEntries(volumeName, bucketName, startKey, numberOfEntries));
+      assertEquals(expectedEntries, km.getRenamesKeyEntries(volumeName, bucketName, startKey, filter, numberOfEntries));
     }
   }
 
@@ -202,7 +216,7 @@ public class TestKeyManagerImpl {
     List<Table.KeyValue<String, OmKeyInfo>> expectedEntries = mockTableIterator(
         OmKeyInfo.class, mockedDeletedDirTable, numberOfVolumes, numberOfBucketsPerVolume, numberOfKeysPerBucket,
         volumeNamePrefix, bucketNamePrefix, keyPrefix, volumeNumber, bucketNumber, startVolumeNumber, startBucketNumber,
-        startKeyNumber, numberOfEntries);
+        startKeyNumber, (kv) -> true, numberOfEntries);
     String volumeName = volumeNumber == null ? null : (String.format("%s%010d", volumeNamePrefix, volumeNumber));
     String bucketName = bucketNumber == null ? null : (String.format("%s%010d", bucketNamePrefix, bucketNumber));
     if (expectedException != null) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -276,6 +276,16 @@ public final class OMRequestTestUtils {
   }
 
   /**
+   * Add key entry to SnapshotRenamedTable.
+   */
+  public static String addRenamedEntryToTable(long trxnLogIndex, String volumeName, String bucketName, String key,
+      OMMetadataManager omMetadataManager) throws Exception {
+    String renameKey = omMetadataManager.getRenameKey(volumeName, bucketName, trxnLogIndex);
+    omMetadataManager.getSnapshotRenamedTable().put(renameKey, key);
+    return renameKey;
+  }
+
+  /**
    * Add key entry to KeyTable. if openKeyTable flag is true, add's entries
    * to openKeyTable, else add's it to keyTable.
    * @throws Exception

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OmSnapshot;
@@ -53,7 +54,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
    * Creates volume, bucket and key entries and adds to OM DB and then
    * deletes these keys to move them to deletedKeys table.
    */
-  private List<String> createAndDeleteKeys(Integer trxnIndex, String bucket)
+  private Pair<List<String>, List<String>> createAndDeleteKeysAndRenamedEntry(Integer trxnIndex, String bucket)
       throws Exception {
     if (bucket == null) {
       bucket = bucketName;
@@ -63,11 +64,14 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
         omMetadataManager);
 
     List<String> ozoneKeyNames = new ArrayList<>(numKeys);
+    List<String> renamedEntries = new ArrayList<>(numKeys);
     for (int i = 1; i <= numKeys; i++) {
       String key = keyName + "-" + i;
       OMRequestTestUtils.addKeyToTable(false, false, volumeName, bucket,
           key, clientID, replicationConfig, trxnIndex++,
           omMetadataManager);
+      renamedEntries.add(OMRequestTestUtils.addRenamedEntryToTable(trxnIndex, volumeName, bucket, key,
+          omMetadataManager));
       ozoneKeyNames.add(omMetadataManager.getOzoneKey(
           volumeName, bucket, key));
     }
@@ -79,14 +83,14 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
       deletedKeyNames.add(deletedKeyName);
     }
 
-    return deletedKeyNames;
+    return Pair.of(deletedKeyNames, renamedEntries);
   }
 
   /**
    * Create OMRequest which encapsulates DeleteKeyRequest.
    * @return OMRequest
    */
-  private OMRequest createPurgeKeysRequest(List<String> deletedKeys,
+  private OMRequest createPurgeKeysRequest(List<String> deletedKeys, List<String> renamedEntries,
        String snapshotDbKey) {
     DeletedKeys deletedKeysInBucket = DeletedKeys.newBuilder()
         .setVolumeName(volumeName)
@@ -94,7 +98,7 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
         .addAllKeys(deletedKeys)
         .build();
     PurgeKeysRequest.Builder purgeKeysRequest = PurgeKeysRequest.newBuilder()
-        .addDeletedKeys(deletedKeysInBucket);
+        .addDeletedKeys(deletedKeysInBucket).addAllRenamedKeys(renamedEntries);
 
     if (snapshotDbKey != null) {
       purgeKeysRequest.setSnapshotTableKey(snapshotDbKey);
@@ -123,16 +127,20 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
   @Test
   public void testValidateAndUpdateCache() throws Exception {
     // Create and Delete keys. The keys should be moved to DeletedKeys table
-    List<String> deletedKeyNames = createAndDeleteKeys(1, null);
+    Pair<List<String>, List<String>> deleteKeysAndRenamedEntry = createAndDeleteKeysAndRenamedEntry(1, null);
 
     // The keys should be present in the DeletedKeys table before purging
-    for (String deletedKey : deletedKeyNames) {
+    for (String deletedKey : deleteKeysAndRenamedEntry.getKey()) {
       assertTrue(omMetadataManager.getDeletedTable().isExist(
           deletedKey));
     }
+    for (String renamedKey : deleteKeysAndRenamedEntry.getValue()) {
+      assertTrue(omMetadataManager.getSnapshotRenamedTable().isExist(renamedKey));
+    }
 
     // Create PurgeKeysRequest to purge the deleted keys
-    OMRequest omRequest = createPurgeKeysRequest(deletedKeyNames, null);
+    OMRequest omRequest = createPurgeKeysRequest(deleteKeysAndRenamedEntry.getKey(),
+        deleteKeysAndRenamedEntry.getValue(), null);
 
     OMRequest preExecutedRequest = preExecute(omRequest);
     OMKeyPurgeRequest omKeyPurgeRequest =
@@ -150,7 +158,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
         omMetadataManager.getStore().initBatchOperation()) {
 
       OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(
-          omResponse, deletedKeyNames, null, null);
+          omResponse, deleteKeysAndRenamedEntry.getKey(), deleteKeysAndRenamedEntry.getValue(), null,
+          null);
       omKeyPurgeResponse.addToDBBatch(omMetadataManager, batchOperation);
 
       // Do manual commit and see whether addToBatch is successful or not.
@@ -158,22 +167,29 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     }
 
     // The keys should not exist in the DeletedKeys table
-    for (String deletedKey : deletedKeyNames) {
+    for (String deletedKey : deleteKeysAndRenamedEntry.getKey()) {
       assertFalse(omMetadataManager.getDeletedTable().isExist(deletedKey));
+    }
+    // Renamed entry should not exist
+    for (String renamedKey : deleteKeysAndRenamedEntry.getValue()) {
+      assertFalse(omMetadataManager.getSnapshotRenamedTable().isExist(renamedKey));
     }
   }
 
   @Test
   public void testKeyPurgeInSnapshot() throws Exception {
     // Create and Delete keys. The keys should be moved to DeletedKeys table
-    List<String> deletedKeyNames = createAndDeleteKeys(1, null);
+    Pair<List<String>, List<String>> deleteKeysAndRenamedEntry = createAndDeleteKeysAndRenamedEntry(1, null);
 
     SnapshotInfo snapInfo = createSnapshot("snap1");
     assertEquals(snapInfo.getLastTransactionInfo(),
         TransactionInfo.valueOf(TransactionInfo.getTermIndex(1L)).toByteString());
     // The keys should be not present in the active Db's deletedTable
-    for (String deletedKey : deletedKeyNames) {
+    for (String deletedKey : deleteKeysAndRenamedEntry.getKey()) {
       assertFalse(omMetadataManager.getDeletedTable().isExist(deletedKey));
+    }
+    for (String renamedKey : deleteKeysAndRenamedEntry.getValue()) {
+      assertFalse(omMetadataManager.getSnapshotRenamedTable().isExist(renamedKey));
     }
 
     UncheckedAutoCloseableSupplier<OmSnapshot> rcOmSnapshot = ozoneManager.getOmSnapshotManager()
@@ -181,14 +197,19 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     OmSnapshot omSnapshot = rcOmSnapshot.get();
 
     // The keys should be present in the snapshot's deletedTable
-    for (String deletedKey : deletedKeyNames) {
+    for (String deletedKey : deleteKeysAndRenamedEntry.getKey()) {
       assertTrue(omSnapshot.getMetadataManager()
           .getDeletedTable().isExist(deletedKey));
     }
+    // The keys should be present in the snapshot's deletedTable
+    for (String renamedKey : deleteKeysAndRenamedEntry.getValue()) {
+      assertTrue(omSnapshot.getMetadataManager()
+          .getSnapshotRenamedTable().isExist(renamedKey));
+    }
 
     // Create PurgeKeysRequest to purge the deleted keys
-    OMRequest omRequest = createPurgeKeysRequest(deletedKeyNames,
-        snapInfo.getTableKey());
+    OMRequest omRequest = createPurgeKeysRequest(deleteKeysAndRenamedEntry.getKey(),
+        deleteKeysAndRenamedEntry.getValue(), snapInfo.getTableKey());
 
     OMRequest preExecutedRequest = preExecute(omRequest);
     OMKeyPurgeRequest omKeyPurgeRequest =
@@ -211,7 +232,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     try (BatchOperation batchOperation =
         omMetadataManager.getStore().initBatchOperation()) {
 
-      OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(omResponse, deletedKeyNames, snapInfo, null);
+      OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(omResponse, deleteKeysAndRenamedEntry.getKey(),
+          deleteKeysAndRenamedEntry.getValue(), snapInfo, null);
       omKeyPurgeResponse.addToDBBatch(omMetadataManager, batchOperation);
 
       // Do manual commit and see whether addToBatch is successful or not.
@@ -220,9 +242,14 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     snapshotInfoOnDisk = omMetadataManager.getSnapshotInfoTable().getSkipCache(snapInfo.getTableKey());
     assertEquals(snapshotInfoOnDisk, snapInfo);
     // The keys should not exist in the DeletedKeys table
-    for (String deletedKey : deletedKeyNames) {
+    for (String deletedKey : deleteKeysAndRenamedEntry.getKey()) {
       assertFalse(omSnapshot.getMetadataManager()
           .getDeletedTable().isExist(deletedKey));
+    }
+
+    for (String renamedEntry : deleteKeysAndRenamedEntry.getValue()) {
+      assertFalse(omSnapshot.getMetadataManager()
+          .getSnapshotRenamedTable().isExist(renamedEntry));
     }
 
     omSnapshot = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the `auditparser` robot tests have a separate directory in the smoketest folder. After the auditparser tool was moved under `ozone debug` in [HDDS-12520](https://issues.apache.org/jira/browse/HDDS-12520) we should move the robot tests to one place too.

## What is the link to the Apache JIRA
[HDDS-13104](https://issues.apache.org/jira/browse/HDDS-13104)

## How was this patch tested?
Acceptance CI: 