### PR TITLE
HDDS-13306. Intermittent failure in testDirectoryDeletingServiceIntervalReconfiguration

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
@@ -109,10 +109,11 @@ public abstract class TestReconfigShell implements NonHATests.TestCase {
         String.format("Updating and restarting DirectoryDeletingService with interval %d %s",
             intervalFromXMLInSeconds, TimeUnit.SECONDS.name().toLowerCase()));
     assertThat(reconfigurationHandler.getConf().get(OZONE_DIR_DELETING_SERVICE_INTERVAL)).isEqualTo(intervalFromXML);
-
-    executeAndAssertStatus("OM", socket);
-    assertThat(out.get()).contains(
-        String.format("SUCCESS: Changed property %s", OZONE_DIR_DELETING_SERVICE_INTERVAL));
+    GenericTestUtils.waitFor(() -> {
+      executeAndAssertStatus("OM", socket);
+      return out.get().contains(
+          String.format("SUCCESS: Changed property %s", OZONE_DIR_DELETING_SERVICE_INTERVAL));
+    }, 1000, 10000);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestReconfigShell.java
@@ -114,8 +114,7 @@ public abstract class TestReconfigShell implements NonHATests.TestCase {
     GenericTestUtils.waitFor(() -> {
       ozoneAdmin.getCmd().execute("reconfig", "--service", "OM", "--address", address, "status");
       String output = out.get();
-      return output.contains("finished") &&
-          output.contains(String.format("SUCCESS: Changed property %s", OZONE_DIR_DELETING_SERVICE_INTERVAL));
+      return output.contains("finished");
     }, 1000, 20000);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
```
org.apache.ozone.test.NonHATests$ReconfigShell.testDirectoryDeletingServiceIntervalReconfiguration -- Time elapsed: 0.138 s <<< FAILURE!

java.lang.AssertionError: 

Expecting actual:
  "OM: Started reconfiguration task on node [localhost:15006].
OM: Reconfiguring status for node [localhost:15006]: started at Fri Jun 20 06:16:46 UTC 2025 and is still running.
"
to contain:
  "SUCCESS: Changed property ozone.directory.deleting.service.interval" 
	at org.apache.hadoop.ozone.shell.TestReconfigShell.testDirectoryDeletingServiceIntervalReconfiguration(TestReconfigShell.java:111)
```
The test failure occurs because the assertion is executed before the reconfiguration task has completed. As a result, the expected success message ("SUCCESS: Changed property ozone.directory.deleting.service.interval") is not yet present in the status command output.

To fix this, we now wait for the reconfiguration task to complete before asserting the status command output.

## What is the link to the Apache JIRA
[HDDS-13306](https://issues.apache.org/jira/browse/HDDS-13306)

## How was this patch tested?
CI: https://github.com/sarvekshayr/ozone/actions/runs/15807271843

flaky-test-check: https://github.com/sarvekshayr/ozone/actions/runs/15829604475/job/44618830714
